### PR TITLE
Bug fixed : User cannot tap over the statusBarView view (needed when …

### DIFF
--- a/MSSlidingPanelController/MSSlidingPanelController.m
+++ b/MSSlidingPanelController/MSSlidingPanelController.m
@@ -616,6 +616,7 @@ typedef NS_ENUM(NSUInteger, MSSPPanTouchLocation)
     [self setStatusBarView:[[UIView alloc] initWithFrame:CGRectMake(0, 0, windowSize.width, 20)]];
     [[self statusBarView] setBackgroundColor:[self centerViewStatusBarColor]];
     [[self statusBarView] setAutoresizingMask:(UIViewAutoresizingFlexibleWidth)];
+    [self statusBarView].userInteractionEnabled = NO;
     
     [self setCenterView:[[MSSlidingPanelCenterView alloc] initWithFrame:CGRectMake(0, 0, windowSize.width, windowSize.height)]];
     [[self centerView] setSlidingPanelController:self];


### PR DESCRIPTION
First thanks for your great lib. We use it at France Télévisions and we are very happy with it.

This pull request is about fixing the following bug : User cannot tap over the statusBarView view. This is needed when in fullscreen mode with no system status bar displayed.

Thanks in advance for integrating it.